### PR TITLE
Added a parse filter function to parse simple and complex filter types.

### DIFF
--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -108,22 +108,35 @@ FuelSoap.prototype.retrieve = function (type, props, filter, callback) {
 		}
 	};
 
-	//TO-DO Rethink the filters - build as function for complex types?
+	// filter can be simple or complex and has three properties leftOperand, rightOperand, and operator
 	if (filter) {
-		body.RetrieveRequestMsg.RetrieveRequest.Filter = {
-			'$': {
-				'xsi:type': 'SimpleFilterPart'
-			},
-			'Property': filter.property,
-			'SimpleOperator': filter.operator,
-			'Value': filter.value
-		}
+		body.RetrieveRequestMsg.RetrieveRequest.Filter = _parseFilter(filter);
 	}
-
-
 
 	self.makeRequest("Retrieve", body, self.handleRequest("RetrieveResponseMsg", callback));
 
+};
+
+// TO-DO Handle other simple filter value types like DateValue
+var _parseFilter = function(filter) {
+    var fType = (_.isObject(filter.leftOperand) && _.isObject(filter.rightOperand)) ? "Complex" : "Simple";
+    var obj = {
+        '$': {
+            'xsi:type': fType + "FilterPart"
+        }
+    };
+
+    if (fType === "Complex") {
+        obj.LeftOperand = _parseFilter(filter.leftOperand);
+        obj.LogicalOperator = filter.operator;
+        obj.RightOperand = _parseFilter(filter.rightOperand);
+    } else {
+        obj.Property = filter.leftOperand;
+        obj.SimpleOperator = filter.operator;
+        obj.Value = filter.rightOperand;
+    }
+
+    return obj;
 };
 
 FuelSoap.prototype.update = function (type, props, options, callback) {


### PR DESCRIPTION
This parser assumes the filter object looks like the following:

``` javascript
// Simple Filters
var sFilter1 = {
    leftOperand: "ID",
    operator: "equals",
    rightOperand: "1234"
};

var sFilter2 = {
    leftOperand: "ID",
    operator: "equals",
    rightOperand: "1234"
};

// Complex Filter
var cFilter = {
    leftOperand: sFilter1,
    operator: "OR",
    rightOperand: sFilter2
};
```

A simple filter is made up of a property and a value. A complex filter is made up of two simple filters and a logical operator.
We still need to decide how to handle dates in the simple filter with the DateValue tag.
