### PR TITLE
Changed AuthClient binding from .on to .once.

### DIFF
--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -283,11 +283,11 @@ FuelSoap.prototype.makeRequest = function (action, req, callback) {
 	requestOptions.headers = this.defaultHeaders;
 	requestOptions.headers.SOAPAction = action;
 
-	this.AuthClient.on('error', function (err) {
+	this.AuthClient.once('error', function (err) {
 		console.log(err);
 	});
 
-	this.AuthClient.on('response', function (body) {
+	this.AuthClient.once('response', function (body) {
 
 		var env = self.buildEnvelope(req, body.accessToken);
 		console.log(env);


### PR DESCRIPTION
When binding to the AuthClient in the makeRequest function, we need to use .once instead of .on to ensure that listeners aren't hanging around for different calls.
