### PR TITLE
makeRequest method: using callbacks inside instead of events because of ...

### DIFF
--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -283,26 +283,25 @@ FuelSoap.prototype.makeRequest = function (action, req, callback) {
 	requestOptions.headers = this.defaultHeaders;
 	requestOptions.headers.SOAPAction = action;
 
-	this.AuthClient.once('error', function (err) {
-		console.log(err);
-	});
+	this.AuthClient.getAccessToken(null, null, function( err, body ) {
 
-	this.AuthClient.once('response', function (body) {
+        if( !!err ) {
+            console.log(err);
+            return;
+        }
 
-		var env = self.buildEnvelope(req, body.accessToken);
-		console.log(env);
-		requestOptions.body = env;
+        var env = self.buildEnvelope(req, body.accessToken);
+        console.log(env);
+        requestOptions.body = env;
 
-		request(requestOptions, function (err, res, body) {
-			if (err) {
-				callback(err, null, null);
-			} else {
-				callback(null, body);
-			}
-		});
-	});
-
-	this.AuthClient.getAccessToken();
+        request(requestOptions, function (err, res, body) {
+            if (err) {
+                callback(err, null, null);
+            } else {
+                callback(null, body);
+            }
+        });
+    });
 };
 
 FuelSoap.prototype.handleRequest = function (key, callback) {


### PR DESCRIPTION
...parallel invocation

I just did a switch of what we currently had. We may want to take into account authOptions like was done in fuel-rest.
