### PR TITLE
added return of errors - breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,13 @@ var SoapClient = new FuelSoap( options );
 SoapClient.retrieve( 
     'Email', 
     ["ID", "Name", "Subject", "CategoryID", "EmailType"], 
-    function( response ) {
-        console.log( response );
+    function( err, res ) {
+        if ( err ) {
+            // error here
+            console.log( err );
+        }
+        
+        console.log( res );
     }
 );
 ```

--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -40,7 +40,6 @@ var FuelSoap = function (options) {
 
 
 FuelSoap.prototype.create = function (type, props, options, callback) {
-	var self = this;
 
     if (arguments.length < 4) {
         //if options are not included
@@ -64,11 +63,14 @@ FuelSoap.prototype.create = function (type, props, options, callback) {
         'xsi:type': type
     };
 
-    self.makeRequest("Create", body, self.handleRequest("CreateResponse", callback));
+    this.soapRequest({
+        action: 'Create',
+        req: body,
+        key: 'CreateResponse'
+    }, callback);
 };
 
 FuelSoap.prototype.retrieve = function (type, props, filter, callback) {
-	var self = this;
 	var defaultProps = ['Client', 'ID', 'ObjectID'];
 
 	if (arguments.length < 4) {
@@ -112,12 +114,15 @@ FuelSoap.prototype.retrieve = function (type, props, filter, callback) {
 		body.RetrieveRequestMsg.RetrieveRequest.Filter = _parseFilter(filter);
 	}
 
-	self.makeRequest("Retrieve", body, self.handleRequest("RetrieveResponseMsg", callback));
-
+    this.soapRequest({
+        action: 'Retrieve',
+        req: body,
+        key: 'RetrieveResponseMsg'
+    }, callback);
 };
 
 // TO-DO Handle other simple filter value types like DateValue
-var _parseFilter = function(filter) {
+FuelSoap.prototype._parseFilter = function(filter) {
     var fType = (_.isObject(filter.leftOperand) && _.isObject(filter.rightOperand)) ? "Complex" : "Simple";
     var obj = {
         '$': {
@@ -139,7 +144,6 @@ var _parseFilter = function(filter) {
 };
 
 FuelSoap.prototype.update = function (type, props, options, callback) {
-    var self = this;
 
     if (arguments.length < 4) {
         //if options are not included
@@ -163,11 +167,14 @@ FuelSoap.prototype.update = function (type, props, options, callback) {
         'xsi:type': type
     };
 
-    self.makeRequest("Update", body, self.handleRequest("UpdateResponse", callback));
+    this.soapRequest({
+        action: 'Update',
+        req: body,
+        key: 'UpdateResponse'
+    }, callback);
 };
 
 FuelSoap.prototype.delete = function (type, props, options, callback) {
-    var self = this;
 
     if (arguments.length < 4) {
         //if options are not included
@@ -191,7 +198,11 @@ FuelSoap.prototype.delete = function (type, props, options, callback) {
         'xsi:type': type
     };
 
-    self.makeRequest("Delete", body, self.handleRequest("DeleteResponse", callback));
+    this.soapRequest({
+        action: 'Delete',
+        req: body,
+        key: 'DeleteResponse'
+    }, callback);
 };
 
 FuelSoap.prototype.query = function () {
@@ -199,7 +210,6 @@ FuelSoap.prototype.query = function () {
 };
 
 FuelSoap.prototype.describe = function (type, callback) {
-	var self = this;
 
 	var body = {
 		DefinitionRequestMsg: {
@@ -214,8 +224,11 @@ FuelSoap.prototype.describe = function (type, callback) {
 		}
 	};
 
-	self.makeRequest("Describe", body, self.handleRequest("DefinitionResponseMsg", callback))
-
+    this.soapRequest({
+        action: 'Describe',
+        req: body,
+        key: 'DefinitionResponseMsg'
+    }, callback);
 };
 
 FuelSoap.prototype.execute = function () {
@@ -246,7 +259,7 @@ FuelSoap.prototype.getSystemStatus = function () {
 
 };
 
-FuelSoap.prototype.buildEnvelope = function (request, token) {
+FuelSoap.prototype._buildEnvelope = function (request, token) {
 
 	var envelope = {
 		'$': {
@@ -275,53 +288,86 @@ FuelSoap.prototype.buildEnvelope = function (request, token) {
 };
 
 
-FuelSoap.prototype.makeRequest = function (action, req, callback) {
-	var self = this;
+FuelSoap.prototype.soapRequest = function (options, callback) {
+    'use strict';
+
+    // we need a callback
+    if( !_.isFunction( callback ) ) {
+        throw new TypeError( 'callback argument is required.' );
+    }
+
+    // we need options
+    if( !_.isPlainObject( options ) ) {
+        this._deliverResponse( 'error', new Error( 'options are required' ), callback, 'FuelSoap - soapRequest' );
+        return;
+    }
 
 	var requestOptions = this.requestOptions;
 	requestOptions.headers = this.defaultHeaders;
-	requestOptions.headers.SOAPAction = action;
+	requestOptions.headers.SOAPAction = options.action;
 
-	this.AuthClient.getAccessToken(function( err, body ) {
+	this.AuthClient.getAccessToken( function( err, body ) {
+        var localError;
 
         if( !!err ) {
-            console.log(err);
+            this._deliverResponse( 'error', err, callback, 'FuelAuth' );
             return;
         }
 
-        var env = self.buildEnvelope(req, body.accessToken);
+        // if there's no access token we have a problem
+        if ( !body.accessToken ) {
+            localError = new Error( 'No access token' );
+            localError.res = body;
+            this._deliverResponse( 'error', localError, callback, 'FuelAuth' );
+            return;
+        }
+
+        var env = this._buildEnvelope(options.req, body.accessToken);
         console.log(env);
         requestOptions.body = env;
 
         request(requestOptions, function (err, res, body) {
             if (err) {
-                callback(err, null, null);
+                this._deliverResponse( 'error', err, callback, 'Request Module inside soapRequest' );
             } else {
-                callback(null, body);
+                this._parseResponse( options.key, body, callback );
             }
-        });
-    });
+        }.bind( this ) );
+    }.bind( this ) );
 };
 
-FuelSoap.prototype.handleRequest = function (key, callback) {
+FuelSoap.prototype._parseResponse = function(key, body, callback) {
+    var parseOptions = {
+        trim: true,
+        normalize: true,
+        explicitArray: false,
+        ignoreAttrs: true
+    };
 
-	var parseOptions = {
-		trim: true,
-		normalize: true,
-		explicitArray: false,
-		ignoreAttrs: true
-	};
-
-	return function (err, body) {
-		if (err) {
-			callback(err);
-		} else {
-			parseString(body, parseOptions, function (err, res) {
-				//TO-DO What other steps might need to be done here on return function?
-				callback(res['soap:Envelope']['soap:Body'][key]);
-			});
-		}
-	}
+    parseString(body, parseOptions, function (err, res) {
+        //TO-DO What other steps might need to be done here on return function?
+        var parsedRes = res['soap:Envelope']['soap:Body'][key];
+        this._deliverResponse( 'response', parsedRes, callback );
+    }.bind( this ) );
 };
+
+FuelSoap.prototype._deliverResponse = function( type, data, callback, errorFrom ) {
+    'use strict';
+
+    // if it's an error and we have where it occured, let's tack it on
+    if( type === 'error' ) {
+
+        if( !!errorFrom ) {
+            data.errorPropagatedFrom = errorFrom;
+        }
+
+        callback( data, null );
+
+    } else if ( type === 'response' ) {
+
+        callback( null, data);
+
+    }
+}
 
 module.exports = FuelSoap;

--- a/test/specs/general-tests.js
+++ b/test/specs/general-tests.js
@@ -11,17 +11,20 @@ describe( 'General Tests', function() {
 
 	it( 'should require auth options', function() {
 		var SoapClient;
+        var options = {
+            auth: {
+                clientId: 'testing'
+                , clientSecret: 'testing'
+            }
+        };
 
 		try {
             SoapClient = new FuelSoap();
         } catch ( err ) {
-            expect( err.message).to.equal( 'options are required. see readme.' );
+            expect( err.message ).to.equal( 'clientId or clientSecret is missing or invalid' );
         }
 
-        SoapClient = new FuelSoap({
-			clientId: 'testing'
-			, clientSecret: 'testing'
-		});
+        SoapClient = new FuelSoap( options );
 
 		// rest client should have an instance of an auth client
 		expect( SoapClient.AuthClient instanceof FuelAuth ).to.be.true;
@@ -29,39 +32,43 @@ describe( 'General Tests', function() {
 
     it( 'should use already initiated fuel auth client', function() {
         var AuthClient, SoapClient;
-
-        AuthClient = new FuelAuth({
+        var authOptions = {
             clientId: 'testing'
             , clientSecret: 'testing'
-        });
+        };
+
+        AuthClient = new FuelAuth( authOptions );
 
         AuthClient.test = true;
 
-        SoapClient = new FuelSoap( AuthClient );
+        SoapClient = new FuelSoap({ auth: AuthClient });
 
         expect( SoapClient.AuthClient.test).to.be.true;
     });
 
 	it( 'should take a custom soap endpoint', function() {
+        var options = {
+            auth: {
+                clientId: 'testing'
+                , clientSecret: 'testing'
+            }
+        };
+
 		// testing default initialization
-		var SoapClient = new FuelSoap({
-			clientId: 'testing'
-			, clientSecret: 'testing'
-		});
+		var SoapClient = new FuelSoap( options );
 
 		expect( SoapClient.requestOptions.uri ).to.equal( 'https://webservice.exacttarget.com/Service.asmx' );
 
+        options.origin = 'https://www.exacttarget.com';
+
 		// testing custom endpoint
-		SoapClient = new FuelSoap({
-			clientId: 'testing'
-			, clientSecret: 'testing'
-		}, 'https://www.exacttarget.com' );
+		SoapClient = new FuelSoap( options );
 
 		expect( SoapClient.requestOptions.uri ).to.equal( 'https://www.exacttarget.com' );
 	});
 
-	it( 'should have makeRequest on prototype', function() {
-		expect( FuelSoap.prototype.makeRequest ).to.be.a( 'function' );
+	it( 'should have soapRequest on prototype', function() {
+		expect( FuelSoap.prototype.soapRequest() ).to.be.a( 'function' );
 	});
 
 	it( 'should have create on prototype', function() {
@@ -112,11 +119,15 @@ describe( 'General Tests', function() {
         expect( FuelSoap.prototype.getSystemStatus ).to.be.a( 'function' );
     });
 
-    it( 'should have buildEnvelope on prototype', function() {
-        expect( FuelSoap.prototype.buildEnvelope ).to.be.a( 'function' );
+    it( 'should have _buildEnvelope on prototype', function() {
+        expect( FuelSoap.prototype._buildEnvelope ).to.be.a( 'function' );
     });
 
-	it( 'should have handleRequest on prototype', function() {
-		expect( FuelSoap.prototype.handleRequest ).to.be.a( 'function' );
+	it( 'should have _parseResponse on prototype', function() {
+		expect( FuelSoap.prototype._parseResponse ).to.be.a( 'function' );
 	});
+
+    it( 'should have _deliverResponse on prototype', function() {
+        expect( FuelRest.prototype._deliverResponse ).to.be.a( 'function' );
+    });
 });


### PR DESCRIPTION
again following the example of Fuel-REST. The callback function now returns error and response. I still need to parse out the SOAP errors but that should not cause another breaking change.
