### PR TITLE
Handle reqOptions Parameters in SOAP Calls

### DIFF
--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -149,6 +149,10 @@ FuelSoap.prototype.create = function (type, props, options, callback) {
 		}
 	};
 
+	if(reqOptions){
+		body = this._addReqOptionsToRequestBody(body, reqOptions);
+	}
+
 	body.CreateRequest.Objects = props;
 	body.CreateRequest.Objects.$ = {
 		'xsi:type': type
@@ -211,6 +215,10 @@ FuelSoap.prototype.retrieve = function (type, props, options, callback) {
 		}
 	};
 
+	if(reqOptions){
+		body = this._addReqOptionsToRequestBody(body, reqOptions);
+	}
+
 	//TO-DO How to handle casing with properties?
 	if(clientIDs) {
 		body.RetrieveRequestMsg.RetrieveRequest.ClientIDs = clientIDs;
@@ -272,6 +280,10 @@ FuelSoap.prototype.update = function (type, props, options, callback) {
 		}
 	};
 
+	if(reqOptions){
+		body = this._addReqOptionsToRequestBody(body, reqOptions);
+	}
+
 	body.UpdateRequest.Objects = props;
 	body.UpdateRequest.Objects.$ = {
 		'xsi:type': type
@@ -305,6 +317,10 @@ FuelSoap.prototype.delete = function (type, props, options, callback) {
 			'Options': options
 		}
 	};
+
+	if(reqOptions){
+		body = this._addReqOptionsToRequestBody(body, reqOptions);
+	}
 
 	body.DeleteRequest.Objects = props;
 	body.DeleteRequest.Objects.$ = {
@@ -394,7 +410,6 @@ FuelSoap.prototype.getSystemStatus = function () {
 };
 
 FuelSoap.prototype._buildEnvelope = function (request, token) {
-
 	var envelope = {
 		'$': {
 			"xmlns": "http://schemas.xmlsoap.org/soap/envelope/",
@@ -490,6 +505,14 @@ FuelSoap.prototype._parseResponse = function(key, body, callback) {
 
 		callback( null, parsedRes );
 	}.bind( this ) );
+};
+
+FuelSoap.prototype._addReqOptionsToRequestBody = function(body, reqOptions){
+	for(var o in reqOptions){
+		body.RetrieveRequestMsg.RetrieveRequest[o] = reqOptions[o];
+	}
+
+	return body;
 };
 
 module.exports = FuelSoap;

--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -150,7 +150,7 @@ FuelSoap.prototype.create = function (type, props, options, callback) {
 	};
 
 	if(reqOptions){
-		body = this._addReqOptionsToRequestBody(body, reqOptions);
+		body = this._addReqOptionsToRequestBody(body, reqOptions, "CreateRequest", "Options");
 	}
 
 	body.CreateRequest.Objects = props;
@@ -216,7 +216,7 @@ FuelSoap.prototype.retrieve = function (type, props, options, callback) {
 	};
 
 	if(reqOptions){
-		body = this._addReqOptionsToRequestBody(body, reqOptions);
+		body = this._addReqOptionsToRequestBody(body, reqOptions, 'RetrieveRequestMsg', 'RetrieveRequest');
 	}
 
 	//TO-DO How to handle casing with properties?
@@ -281,7 +281,7 @@ FuelSoap.prototype.update = function (type, props, options, callback) {
 	};
 
 	if(reqOptions){
-		body = this._addReqOptionsToRequestBody(body, reqOptions);
+		body = this._addReqOptionsToRequestBody(body, reqOptions, "UpdateRequest", "Options");
 	}
 
 	body.UpdateRequest.Objects = props;
@@ -319,7 +319,7 @@ FuelSoap.prototype.delete = function (type, props, options, callback) {
 	};
 
 	if(reqOptions){
-		body = this._addReqOptionsToRequestBody(body, reqOptions);
+		body = this._addReqOptionsToRequestBody(body, reqOptions, "DeleteRequest", "Options");
 	}
 
 	body.DeleteRequest.Objects = props;
@@ -507,9 +507,9 @@ FuelSoap.prototype._parseResponse = function(key, body, callback) {
 	}.bind( this ) );
 };
 
-FuelSoap.prototype._addReqOptionsToRequestBody = function(body, reqOptions){
+FuelSoap.prototype._addReqOptionsToRequestBody = function(body, reqOptions, root, child){
 	for(var o in reqOptions){
-		body.RetrieveRequestMsg.RetrieveRequest[o] = reqOptions[o];
+		body[root][child][o] = reqOptions[o];
 	}
 
 	return body;

--- a/test/specs/general-tests.js
+++ b/test/specs/general-tests.js
@@ -101,6 +101,33 @@ describe( 'General Tests', function() {
 		expect( SoapClient.requestOptions.uri ).to.equal( 'https://www.exacttarget.com' );
 	});
 
+	it( 'should expect req options', function() {
+		var options = {
+			auth: {
+				clientId: 'testing'
+				, clientSecret: 'testing'
+			}
+			, reqOptions: {
+	            QueryAllAccounts: true
+	        }
+		}, SoapClient = new FuelSoap( options );
+
+		var body = {
+			'RetrieveRequestMsg': {
+				'$': {
+					'xmlns': 'http://exacttarget.com/wsdl/partnerAPI'
+				},
+				"RequestOptions": {}
+			}
+		};
+		
+		if( options.reqOptions ) {
+			body = SoapClient._addReqOptionsToRequestBody(body, options.reqOptions, 'RetrieveRequestMsg', 'RequestOptions');
+		}
+		
+		expect( body.RetrieveRequestMsg.RequestOptions.QueryAllAccounts ).to.be.true;
+	});
+
 	it( 'should have soapRequest on prototype', function() {
 		expect( FuelSoap.prototype.soapRequest ).to.be.a( 'function' );
 	});
@@ -159,5 +186,9 @@ describe( 'General Tests', function() {
 
 	it( 'should have _parseResponse on prototype', function() {
 		expect( FuelSoap.prototype._parseResponse ).to.be.a( 'function' );
+	});
+
+	it( 'should have _addReqOptionsToRequestBody on prototype', function() {
+		expect( FuelSoap.prototype._addReqOptionsToRequestBody ).to.be.a( 'function' );
 	});
 });


### PR DESCRIPTION
Added handling for reqOptions parameters passed into retrieve, create, update, and delete methods