### PR TITLE
add missing bind

### DIFF
--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -106,7 +106,7 @@ FuelSoap.prototype.soapRequest = function(options, callback) {
 				} else {
 					helpers.deliverResponse('response', { body: data, res: res }, callback);
 				}
-			});
+			}.bind(this));
 		}.bind(this));
 	}.bind(this));
 };


### PR DESCRIPTION
This should fix a rarely occurring error:

TypeError: Cannot call method 'soapRequest' of undefined
    at /var/task/node_modules/fuelsdk-node/node_modules/fuel-soap/lib/fuel-soap.js:118:11