### PR TITLE
adding support for OAuth2

### DIFF
--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -102,6 +102,10 @@ FuelSoap.prototype.soapRequest = function(options, callback) {
 			return;
 		}
 
+		if(this.AuthClient.authVersion === 2 && body.soap_instance_url) {
+			requestOptions.uri = body.soap_instance_url + 'Service.asmx';
+		}
+
 		retry       = options.retry || false;
 		authOptions = clone(options.auth);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuel-soap",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Node library for performing SOAP API calls to Salesforce Marketing Cloud (formerly ExactTarget).",
   "main": "./lib/fuel-soap.js",
   "scripts": {


### PR DESCRIPTION
Change is to fetch Soap Tenant Specific endpoint from the OAuth2 token call when customer use OAuth2 authentication.