### PR TITLE
implementing extract with tabs and docs

### DIFF
--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -582,10 +582,18 @@ FuelSoap.prototype._parseResponse = function(key, body, callback) {
 
 		var parsedRes = soapBody[key];
 
-		if(key === "PerformExtractMsg") {
+		if(key === 'PerformExtractMsg') {
 			parsedRes = soapBody.ExtractResponseMsg;
-			callback(null, parsedRes);
-			return;
+			if(parsedRes.OverallStatus !== 'OK') {
+				soapError = new Error(`Soap Error`);
+				soapError.requestId = parsedRes.RequestID;
+				soapError.results = parsedRes.Results;
+				soapError.errorPropagatedFrom = key;
+				callback(soapError, null);
+				return;
+			}
+				callback(null, parsedRes);
+				return;
 		}
 
 		if(key === 'DefinitionResponseMsg') {
@@ -690,7 +698,7 @@ FuelSoap.prototype.schedule = function(type,schedule,interactions, action, optio
  */
 FuelSoap.prototype.extract = function(request, callback) {
 	var body = {
-		PerformExtractMsg: {
+		ExtractRequestMsg: {
 			$: {
 				xmlns: 'http://exacttarget.com/wsdl/partnerAPI'
 			}

--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -582,6 +582,12 @@ FuelSoap.prototype._parseResponse = function(key, body, callback) {
 
 		var parsedRes = soapBody[key];
 
+		if(key === "PerformExtractMsg") {
+			parsedRes = soapBody.ExtractResponseMsg;
+			callback(null, parsedRes);
+			return;
+		}
+
 		if(key === 'DefinitionResponseMsg') {
 			// Return empty object if no ObjectDefinition is returned.
 			parsedRes.ObjectDefinition = parsedRes.ObjectDefinition || {};
@@ -676,9 +682,33 @@ FuelSoap.prototype.schedule = function(type,schedule,interactions, action, optio
 	}, callback);
 };
 
+/**
+ * This method handles the Schedule SOAP Action Extract
+ * @memberof FuelSoap
+ * @param {Object} request - Value set in body as `ExtractRequestMsg.Requests`
+ * @param {FuelSoap~StandardCallback} callback - Callback that handles response
+ */
+FuelSoap.prototype.extract = function(request, callback) {
+	var body = {
+		PerformExtractMsg: {
+			$: {
+				xmlns: 'http://exacttarget.com/wsdl/partnerAPI'
+			}
+			,
+			'Requests': request
+		}
+	};
+
+	this.soapRequest({
+		action: 'Extract'
+		, req: body
+		, key: 'PerformExtractMsg'
+		, retry: true
+	}, callback);
+};
+
 // Methods that need implementations
 FuelSoap.prototype.configure = function() {};
-FuelSoap.prototype.extract = function() {};
 FuelSoap.prototype.getSystemStatus = function() {};
 FuelSoap.prototype.query = function() {};
 FuelSoap.prototype.versionInfo = function() {};

--- a/test/specs/general-tests.js
+++ b/test/specs/general-tests.js
@@ -126,7 +126,6 @@ describe('General Tests', function() {
 	// need to be removed
 	notImplementedMethods = [
 		'configure'
-		, 'extract'
 		, 'getSystemStatus'
 		, 'query'
 		, 'versionInfo'

--- a/test/specs/soap-action-extract.js
+++ b/test/specs/soap-action-extract.js
@@ -43,7 +43,7 @@ describe('SOAP Action - extract', function() {
 		FuelSoap.prototype.extract(sampleRequest, function() {});
 
 		// Assert
-		assert.equal(soapRequestSpy.args[0][0].req.PerformExtractMsg.Requests, sampleRequest);
+		assert.equal(soapRequestSpy.args[0][0].req.ExtractRequestMsg.Requests, sampleRequest);
 	});
 
 	it('should pass callback to soapRequest', function() {

--- a/test/specs/soap-action-extract.js
+++ b/test/specs/soap-action-extract.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+'use strict';
+
+var assert   = require('assert');
+var FuelSoap = require('../../lib/fuel-soap');
+var sinon    = require('sinon');
+
+describe('SOAP Action - extract', function() {
+	var soapRequestSpy;
+	var simpleVerifyTestCases = [
+		{ property: 'action', expected: 'Extract' }
+		, { property: 'key', expected: 'PerformExtractMsg' }
+		, { property: 'retry', expected: true }
+	];
+
+	beforeEach(function() {
+		soapRequestSpy = sinon.stub(FuelSoap.prototype, 'soapRequest');
+	});
+
+	afterEach(function() {
+		FuelSoap.prototype.soapRequest.restore();
+	});
+
+	simpleVerifyTestCases.forEach(function(testCase) {
+		it('should call soapRequest with correct ' + testCase.property, function() {
+			// Act
+			FuelSoap.prototype.extract({ data: true }, function() {});
+
+			// Assert
+			assert.equal(soapRequestSpy.args[0][0][testCase.property], testCase.expected);
+		});
+	});
+
+	it('should call soapRequest with proper body', function() {
+		// Act
+		var sampleRequest = { data: true };
+		FuelSoap.prototype.extract(sampleRequest, function() {});
+
+		// Assert
+		assert.equal(soapRequestSpy.args[0][0].req.PerformExtractMsg.Requests, sampleRequest);
+	});
+
+	it('should pass callback to soapRequest', function() {
+		// Arrange
+		var sampleCallback = sinon.spy();
+
+		// Act
+		FuelSoap.prototype.extract({ data: true }, sampleCallback);
+
+		// Assert
+		assert.ok(soapRequestSpy.calledWith(sinon.match.object, sampleCallback));
+	});
+});
+


### PR DESCRIPTION
I noticed that the SOAP extract function has not been implemented and needed it to be implemented for the project that I'm working on.

To the best of my knowledge, this is the way that I think this should be implemented. That said I know nothing of the error codes that could be returned by the extract method if I knew that then I could check and act upon them before executing the callback function.

I have tested this manually as I was trying to perform a Data Extension Extract to the local FTP server, I received a 200 status code and no error message, but the Data Extension Extract CSV file never appeared on the FTP server, if anyone could provide any assistance on Data Extension or File Extracts via the SOAP API I would be highly grateful.