### PR TITLE
Support for the BatchSize in retrieve requests

### DIFF
--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -207,6 +207,7 @@ FuelSoap.prototype.retrieve = function(type, props, options, callback) {
 	var continueReq  = null;
 	var defaultProps = ['Client', 'ID', 'ObjectID'];
 	var filter       = null;
+	var batchSize    = Number.NaN;
 	var reqOptions;
 	var updateQueryAllAccounts;
 
@@ -239,6 +240,7 @@ FuelSoap.prototype.retrieve = function(type, props, options, callback) {
 		clientIDs = options.clientIDs;
 		continueReq = options.continueRequest;
 		filter    = options.filter;
+		batchSize = Math.round(Number(options.batchSize));
 	}
 
 	updateQueryAllAccounts = configureQueryAllAccounts(options);
@@ -263,6 +265,9 @@ FuelSoap.prototype.retrieve = function(type, props, options, callback) {
 	// filter can be simple or complex and has three properties leftOperand, rightOperand, and operator
 	if(filter) {
 		body.RetrieveRequestMsg.RetrieveRequest.Filter = this._parseFilter(filter);
+	}
+	if (batchSize > 0) {
+		body.RetrieveRequestMsg.RetrieveRequest.Options = { BatchSize: batchSize };
 	}
 
 	updateQueryAllAccounts(body.RetrieveRequestMsg, 'RetrieveRequest');


### PR DESCRIPTION
My very simple take on adding support for batching the retrieve requests. There was no support at all for the BatchSize option.
Hoping you find this useful and satisfactory.

For clarity, you use it the same way you use the filter option:

```javascript
const options = options: { filter: myFilter, batchSize: 50 }
SoapClient.retrieve(type, props, options, callback);
```

Regards

P.S.: You might have noticed an identical pull request before. I closed it because I had mistakenly made it from my master branch. This is the correct one.